### PR TITLE
Increase prime range

### DIFF
--- a/basicmath-py/tests/test_primes.py
+++ b/basicmath-py/tests/test_primes.py
@@ -47,8 +47,23 @@ def test_large_primes() -> None:
     Useful URL:
     https://markknowsnothing.weebly.com/primes.html
     """
+    # billions
     assert bm.check_prime(1_000_082_257)
-    # assert bm.check_prime(1000000071143)
+    assert bm.check_prime(314_159_265_359)
+
+    # trillions
+    assert bm.check_prime(1_000_000_071_143)
+    assert bm.check_prime(1_000_000_026_959)
+    assert bm.check_prime(1_000_000_099_643)
+
+    # (almost) quadrillions
+    assert bm.check_prime(900_000_000_014_261)
+    assert bm.check_prime(950_000_000_072_087)
+    assert bm.check_prime(999_999_999_999_989)
+
+    # values that should fail
+    assert not bm.check_prime(101_010_101_010)
+    assert not bm.check_prime(999_999_999_999_998)
 
 
 if __name__ == "__main__":

--- a/basicmath-py/tests/test_primes.py
+++ b/basicmath-py/tests/test_primes.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import basicmath as bm
 
-MAX_POWERS: int = 4  # TODO: can go up to 12
+MAX_POWERS: int = 7  # TODO: can go up to 12
 NUMBERS_TO_CHECK: list[int] = [int(10**k) for k in range(1, MAX_POWERS)]
 MAX_NUMBERS: int = NUMBERS_TO_CHECK[-1]
 

--- a/basicmath-py/tests/test_primes.py
+++ b/basicmath-py/tests/test_primes.py
@@ -40,5 +40,16 @@ def test_prime_count() -> None:
         # print(f"{n}: {c} vs. {PRIME_RESULTS.get(n)}")
 
 
+def test_large_primes() -> None:
+    """
+    Testing prime count for large primes.
+
+    Useful URL:
+    https://markknowsnothing.weebly.com/primes.html
+    """
+    assert bm.check_prime(1_000_082_257)
+    # assert bm.check_prime(1000000071143)
+
+
 if __name__ == "__main__":
     test_prime_count()

--- a/basicmath-src/miller_rabin.cpp
+++ b/basicmath-src/miller_rabin.cpp
@@ -5,6 +5,22 @@
 
 /**
  * @brief
+ * Taking the mod of a product of two numbers, (a * b) mod n,
+ * specific to non-negative integer inputs.
+ *
+ * @param a first number.
+ * @param b second number.
+ * @param n modulus.
+ *
+ * @returns uint64 representing (a * b) mod n.
+ */
+std::uint64_t mod_product(std::uint64_t a, std::uint64_t b, std::uint64_t n) noexcept
+{
+    return ((a % n) * (b % n)) % n;
+}
+
+/**
+ * @brief
  * Taking the mod of an exponential number, a^b mod n,
  * specific to non-negative integer inputs.
  *
@@ -12,7 +28,7 @@
  * @param b power.
  * @param n modulus.
  *
- * @returns UInt64 representing a^b mod n.
+ * @returns uint64 representing a^b mod n.
  *
  * @details
  * Implements `MODULAR-EXPONENTIATION` from Cormen, Section 31.6 Page 957.
@@ -31,13 +47,13 @@ std::uint64_t mod_exponentiation(std::uint64_t a, std::uint64_t b, std::uint64_t
     {
         // do this every step
         c *= 2;
-        d = (d * d) % n;
+        d = mod_product(d, d, n);
 
         // if this bit is active, do extra
         if (b & bit_holder)
         {
             c += 1;
-            d = (d * a) % n;
+            d = mod_product(d, a, n);
         }
 
         // shift bit
@@ -76,7 +92,7 @@ bool check_composite_from_witness(std::uint64_t n, std::uint64_t a) noexcept
     // checking up to t
     for (std::uint64_t i = 0; i < t; ++i)
     {
-        x1 = (x0 * x0) % n;
+        x1 = mod_product(x0, x0, n);
         if (x1 == 1 && x0 != 1 && x0 != n - 1)
         {
             return true;

--- a/basicmath-src/miller_rabin.cpp
+++ b/basicmath-src/miller_rabin.cpp
@@ -58,11 +58,17 @@ std::uint64_t mod_product(std::uint64_t a, std::uint64_t b, std::uint64_t n) noe
  *
  * @details
  * Implements `MODULAR-EXPONENTIATION` from Cormen, Section 31.6 Page 957.
+ *
+ * @note
+ * In this code, there is a variable `c` that is commented out.
+ * It is used in the loop invariant from the algorithm as presented by Cormen.
+ * In other cases, it may be useful to track/store the value of `c`,
+ * but for pure computation it is not necessary.
  */
 std::uint64_t mod_exponentiation(std::uint64_t a, std::uint64_t b, std::uint64_t n) noexcept
 {
     // setup
-    std::uint64_t c = 0;
+    // std::uint64_t c = 0;
     std::uint64_t d = 1;
 
     // holding bit to move through, has 1 in first bit place
@@ -72,13 +78,13 @@ std::uint64_t mod_exponentiation(std::uint64_t a, std::uint64_t b, std::uint64_t
     while (bit_holder)
     {
         // do this every step
-        c *= 2;
+        // c *= 2;
         d = mod_product(d, d, n);
 
         // if this bit is active, do extra
         if (b & bit_holder)
         {
-            c += 1;
+            // c += 1;
             d = mod_product(d, a, n);
         }
 

--- a/basicmath-src/miller_rabin.cpp
+++ b/basicmath-src/miller_rabin.cpp
@@ -1,35 +1,47 @@
-#include <stdexcept>
+#include <cstdint>
 #include <stdlib.h>
 
 #include "miller_rabin.hpp"
 
 /**
  * @brief
- * Taking the mod of an exponential number, a^c mod n,
- * specific to integer inputs.
+ * Taking the mod of an exponential number, a^b mod n,
+ * specific to non-negative integer inputs.
  *
  * @param a base.
- * @param b limit of increments to c.
+ * @param b power.
  * @param n modulus.
  *
- * @returns integer representing a^c mod n.
+ * @returns UInt64 representing a^b mod n.
  *
  * @details
  * Implements `MODULAR-EXPONENTIATION` from Cormen, Section 31.6 Page 957.
  */
-int mod_exponentiation(int a, unsigned b, int n) noexcept
+std::uint64_t mod_exponentiation(std::uint64_t a, std::uint64_t b, std::uint64_t n) noexcept
 {
-    int c = 0;
-    int d = 1;
-    for (unsigned k = 1 << 31; k > 0; k = k / 2)
+    // setup
+    std::uint64_t c = 0;
+    std::uint64_t d = 1;
+
+    // holding bit to move through, has 1 in first bit place
+    std::uint64_t bit_holder = 0b1000000000000000000000000000000000000000000000000000000000000000;
+
+    // loop through all bits, will end once bit_holder is 0
+    while (bit_holder)
     {
+        // do this every step
         c *= 2;
         d = (d * d) % n;
-        if (b & k)
+
+        // if this bit is active, do extra
+        if (b & bit_holder)
         {
             c += 1;
             d = (d * a) % n;
         }
+
+        // shift bit
+        bit_holder >>= 1;
     }
     return d;
 }

--- a/basicmath-src/miller_rabin.cpp
+++ b/basicmath-src/miller_rabin.cpp
@@ -58,21 +58,23 @@ std::uint64_t mod_exponentiation(std::uint64_t a, std::uint64_t b, std::uint64_t
  * @details
  * Implements `WITNESS` from Cormen, Section 31.8 Page 969.
  */
-bool check_composite_from_witness(int n, int a) noexcept
+bool check_composite_from_witness(std::uint64_t n, std::uint64_t a) noexcept
 {
     // figuring out what t and u have to be from n
-    int m = n - 1;
-    int t = 0;
-    while (m % 2 == 0)
+    std::uint64_t u = n - 1;
+    std::uint64_t t = 0;
+    while (u % 2 == 0)
     {
         ++t;
-        m /= 2;
+        u /= 2;
     }
-    unsigned u = (unsigned)m;
 
-    int x0 = mod_exponentiation(a, u, n);
-    int x1;
-    for (int i = 0; i < t; ++i)
+    // compute mod exponentiation a^u mod n
+    std::uint64_t x0 = mod_exponentiation(a, u, n);
+    std::uint64_t x1;
+
+    // checking up to t
+    for (std::uint64_t i = 0; i < t; ++i)
     {
         x1 = (x0 * x0) % n;
         if (x1 == 1 && x0 != 1 && x0 != n - 1)

--- a/basicmath-src/miller_rabin.cpp
+++ b/basicmath-src/miller_rabin.cpp
@@ -13,10 +13,36 @@
  * @param n modulus.
  *
  * @returns uint64 representing (a * b) mod n.
+ *
+ * @details
+ * This is fundamentally based on the reduction formula
+ * (a * b) % n = ((a % n) * (b % n)) % n.
+ * We then iteratively step through the binary representation of b.
  */
 std::uint64_t mod_product(std::uint64_t a, std::uint64_t b, std::uint64_t n) noexcept
 {
-    return ((a % n) * (b % n)) % n;
+    std::uint64_t result = 0;
+
+    // intermediate computation of a % n
+    a %= n;
+
+    // looping through all bits of b
+    while (b)
+    {
+        // if least significant bit is active, add a to the result
+        if (b & 1)
+        {
+            result = (result + a) % n;
+        }
+
+        // right bit shift b
+        b >>= 1;
+
+        // double a to prepare for the next bit of n
+        a = (2 * a) % n;
+    }
+
+    return result;
 }
 
 /**

--- a/basicmath-src/miller_rabin.cpp
+++ b/basicmath-src/miller_rabin.cpp
@@ -1,5 +1,5 @@
 #include <cstdint>
-#include <stdlib.h>
+#include <random>
 
 #include "miller_rabin.hpp"
 
@@ -97,7 +97,7 @@ bool check_composite_from_witness(std::uint64_t n, std::uint64_t a) noexcept
  * @details
  * Implements `MILLER-RABIN` from Cormen, Section 31.8 Page 970.
  */
-bool miller_rabin(int n, int s) noexcept
+bool miller_rabin(std::uint64_t n, int s) noexcept
 {
     // false if number is even or less than 2
     if (n % 2 == 0 || n < 2)
@@ -105,11 +105,17 @@ bool miller_rabin(int n, int s) noexcept
         return false;
     }
 
+    // setting up random number generation for Unif(1, n - 1)
+    std::random_device rand_dev;
+    std::mt19937_64 rand_rng(rand_dev());
+    std::uniform_int_distribution<std::uint64_t> rand_dist(1, n - 1);
+
     // looping through max number of iterations
+    std::uint64_t a;
     for (int k = 0; k < s; ++k)
     {
-        // generates random number between 1 and n - 1
-        int a = (rand() % (n - 1)) + 1;
+        // generates new number
+        a = rand_dist(rand_rng);
 
         // return false if number is composite
         if (check_composite_from_witness(n, a))
@@ -117,5 +123,7 @@ bool miller_rabin(int n, int s) noexcept
             return false;
         }
     }
+
+    // after s checks, returns true
     return true;
 }

--- a/basicmath-src/miller_rabin.hpp
+++ b/basicmath-src/miller_rabin.hpp
@@ -1,6 +1,8 @@
 #ifndef PRIME_H
 #define PRIME_H
 
+#include <cstdint>
+
 /**
  * @brief
  * Checks if number is prime using Miller-Rabin prime tester.
@@ -11,6 +13,6 @@
  * @returns
  * true if number is prime, false if number is not prime.
  */
-bool miller_rabin(int n, int s) noexcept;
+bool miller_rabin(std::uint64_t n, int s) noexcept;
 
 #endif


### PR DESCRIPTION
Initial implementation of Miller-Rabin was not optimal, and spot checking showed it did not work for numbers >= 1 billion.
In addition, the implementation was not the best.

This pull request does the following:
- Re-does implementation using 64-bit unsigned ints.
- Properly moves through bits when computing `mod_exponentiation`.
- Uses C++ `<random>` header functionality.
- Accounts for overflow when computing modulus.
- Adds more Python unit tests to show accuracy of improvements.